### PR TITLE
급식 조회시 날짜만 입력 받도록 변경

### DIFF
--- a/src/main/kotlin/com/project/school/domain/school/adapter/input/data/request/FindSchoolMealRequest.kt
+++ b/src/main/kotlin/com/project/school/domain/school/adapter/input/data/request/FindSchoolMealRequest.kt
@@ -1,7 +1,5 @@
 package com.project.school.domain.school.adapter.input.data.request
 
 data class FindSchoolMealRequest(
-    val educationCode: String,
-    val adminCode: String,
     val date: String
 )

--- a/src/main/kotlin/com/project/school/domain/school/adapter/input/mapper/SchoolDataMapper.kt
+++ b/src/main/kotlin/com/project/school/domain/school/adapter/input/mapper/SchoolDataMapper.kt
@@ -29,8 +29,6 @@ class SchoolDataMapper {
 
     infix fun toDto(request: FindSchoolMealRequest): FindSchoolMealDto =
         FindSchoolMealDto(
-            educationCode = request.educationCode,
-            adminCode = request.adminCode,
             date = request.date
         )
 

--- a/src/main/kotlin/com/project/school/domain/school/application/port/input/dto/FindSchoolMealDto.kt
+++ b/src/main/kotlin/com/project/school/domain/school/application/port/input/dto/FindSchoolMealDto.kt
@@ -1,7 +1,5 @@
 package com.project.school.domain.school.application.port.input.dto
 
 data class FindSchoolMealDto(
-    val educationCode: String,
-    val adminCode: String,
     val date: String
 )

--- a/src/main/kotlin/com/project/school/domain/school/application/service/FindSchoolMealService.kt
+++ b/src/main/kotlin/com/project/school/domain/school/application/service/FindSchoolMealService.kt
@@ -27,8 +27,8 @@ class FindSchoolMealService(
             "json",
             page,
             3,
-            dto.educationCode,
-            dto.adminCode,
+            account.school.educationCode,
+            account.school.adminCode,
             dto.date
         )
         return schoolMeal.map {


### PR DESCRIPTION
## 💡 개요
- 급식 조회시 날짜만 입력 받도록 변경 하였습니다.
## 📃 작업사항
- 급식 조회 dto와 request에서 adminCode와 educationCode를 제거했습니다.
- 급식 조회 서비스에서 account에서 adminCode와 educationCode를 가져오도록 변경했습니다.
## 🙋‍♂️ 리뷰내용