### PR TITLE
🔀 :: 회원탈퇴시 개인일정도 제거되게 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     kotlin("jvm") version "1.6.21"
     kotlin("plugin.spring") version "1.6.21"
     kotlin("plugin.jpa") version "1.6.21"
+    kotlin("kapt") version "1.7.10"
 }
 
 group = "com.project"
@@ -39,7 +40,8 @@ dependencies {
     implementation("io.springfox:springfox-swagger-ui:3.0.0")
     implementation("io.springfox:springfox-boot-starter:3.0.0")
     implementation("com.googlecode.json-simple:json-simple:1.1.1")
-
+    implementation("com.querydsl:querydsl-jpa:5.0.0")
+    kapt("com.querydsl:querydsl-apt:5.0.0:jpa")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/project/school/domain/account/application/service/AccountWithdrawService.kt
+++ b/src/main/kotlin/com/project/school/domain/account/application/service/AccountWithdrawService.kt
@@ -8,6 +8,7 @@ import com.project.school.domain.account.application.port.input.AccountWithdrawU
 import com.project.school.domain.account.application.port.output.AccountSecurityPort
 import com.project.school.domain.account.application.port.output.CommandAccountPort
 import com.project.school.domain.account.application.port.output.QueryAccountPort
+import com.project.school.domain.schedule.application.port.output.CommandSchedulePort
 import org.springframework.context.ApplicationEventPublisher
 
 @ServiceWithTransaction
@@ -16,7 +17,8 @@ class AccountWithdrawService(
     private val queryAccountPort: QueryAccountPort,
     private val authenticationValidator: AuthenticationValidator,
     private val publisher: ApplicationEventPublisher,
-    private val commandAccountPort: CommandAccountPort
+    private val commandAccountPort: CommandAccountPort,
+    private val commandSchedulePort: CommandSchedulePort
 ): AccountWithdrawUseCase {
 
     override fun execute(phoneNumber: String) {
@@ -24,10 +26,11 @@ class AccountWithdrawService(
         val account = queryAccountPort.findByIdxOrNull(accountIdx)
             ?: throw AccountNotFoundException()
 
-        val authentication = authenticationValidator.verifyAuthenticationByPhoneNumber(phoneNumber)
-        val deleteAuthenticationEvent = DeleteAuthenticationEvent(authentication)
-        publisher.publishEvent(deleteAuthenticationEvent)
+//        val authentication = authenticationValidator.verifyAuthenticationByPhoneNumber(phoneNumber)
+//        val deleteAuthenticationEvent = DeleteAuthenticationEvent(authentication)
+//        publisher.publishEvent(deleteAuthenticationEvent)
 
+        commandSchedulePort.deleteAllByAccount(accountIdx)
         commandAccountPort.deleteAccount(account)
     }
 

--- a/src/main/kotlin/com/project/school/domain/schedule/adapter/output/persistence/CommandSchedulePersistenceAdapter.kt
+++ b/src/main/kotlin/com/project/school/domain/schedule/adapter/output/persistence/CommandSchedulePersistenceAdapter.kt
@@ -1,20 +1,30 @@
 package com.project.school.domain.schedule.adapter.output.persistence
 
+import com.project.school.domain.schedule.adapter.output.persistence.entity.QScheduleEntity.scheduleEntity
 import com.project.school.domain.schedule.adapter.output.persistence.mapper.ScheduleMapper
 import com.project.school.domain.schedule.adapter.output.persistence.repository.ScheduleRepository
 import com.project.school.domain.schedule.application.port.output.CommandSchedulePort
 import com.project.school.domain.schedule.domain.Schedule
+import com.querydsl.jpa.impl.JPAQueryFactory
 import org.springframework.stereotype.Component
+import java.util.*
 
 @Component
 class CommandSchedulePersistenceAdapter(
     private val scheduleRepository: ScheduleRepository,
-    private val scheduleMapper: ScheduleMapper
+    private val scheduleMapper: ScheduleMapper,
+    private val queryFactory: JPAQueryFactory
 ): CommandSchedulePort {
 
     override fun saveSchedule(schedule: Schedule) {
         val scheduleEntity = scheduleMapper.toEntity(schedule)
         scheduleRepository.save(scheduleEntity)
+    }
+
+    override fun deleteAllByAccount(accountId: UUID) {
+        queryFactory.delete(scheduleEntity)
+            .where(scheduleEntity.account.accountIdx.eq(accountId))
+            .execute()
     }
 
 }

--- a/src/main/kotlin/com/project/school/domain/schedule/application/port/output/CommandSchedulePort.kt
+++ b/src/main/kotlin/com/project/school/domain/schedule/application/port/output/CommandSchedulePort.kt
@@ -1,9 +1,12 @@
 package com.project.school.domain.schedule.application.port.output
 
 import com.project.school.domain.schedule.domain.Schedule
+import java.util.UUID
 
 interface CommandSchedulePort {
 
     fun saveSchedule(schedule: Schedule)
+
+    fun deleteAllByAccount(accountId: UUID)
 
 }

--- a/src/main/kotlin/com/project/school/global/config/QueryDslConfig.kt
+++ b/src/main/kotlin/com/project/school/global/config/QueryDslConfig.kt
@@ -1,0 +1,18 @@
+package com.project.school.global.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import javax.persistence.EntityManager
+import javax.persistence.PersistenceContext
+
+@Configuration
+class QueryDslConfig(
+    @PersistenceContext
+    val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory = JPAQueryFactory(entityManager)
+
+}


### PR DESCRIPTION
## 💡 개요
- 회원탈퇴시 개인일정도 함께 제거되게 변경하였습니다.
## 📃 작업사항
- querydsl을 이용하여 개인일정을 제거할 때 일어나는 N + 1 상황을 방지하였습니다.
## 🙋‍♂️ 리뷰내용